### PR TITLE
ReadMe.md> BUG：YCM补全菜单颜色，背景颜色和文字颜色反了

### DIFF
--- a/README.md
+++ b/README.md
@@ -1485,9 +1485,9 @@ def FlagsForFile( filename, \*\*kwargs ):
 ```
 " YCM 补全菜单配色
 " 菜单
-highlight Pmenu ctermfg=2 ctermbg=3 guifg=#005f87 guibg=#EEE8D5
+highlight Pmenu ctermfg=2 ctermbg=3 guifg=#EEE8D5 guibg=#005f87
 " 选中项
-highlight PmenuSel ctermfg=2 ctermbg=3 guifg=#AFD700 guibg=#106900
+highlight PmenuSel ctermfg=2 ctermbg=3 guifg=#106900 guibg=#AFD700
 " 补全功能在注释中同样有效
 let g:ycm_complete_in_comments=1
 " 允许 vim 加载 .ycm_extra_conf.py 文件，不再提示


### PR DESCRIPTION
1488行和1490行，我将guifg的颜色和guibg的颜色调换了一下